### PR TITLE
Add the option to configure wether mysql connector uses ssl or not

### DIFF
--- a/src/Changelog.txt
+++ b/src/Changelog.txt
@@ -1,3 +1,5 @@
+5.6:
+  - Add the ability to declare that mysql uses SSL
 5.5:
   - Change dependency locations so h2 and mysql-connector will auto download again.
   - Fix messages' colour translation.

--- a/src/com/iConomy/net/Database.java
+++ b/src/com/iConomy/net/Database.java
@@ -28,7 +28,7 @@ public class Database
       this.password = "sa";
     } else if (Constants.DatabaseType.equalsIgnoreCase("mysql")) {
       this.driver = "com.mysql.jdbc.Driver";
-      this.dsn = ("jdbc:mysql://" + Constants.SQLHostname + ":" + Constants.SQLPort + "/" + Constants.SQLDatabase);
+      this.dsn = ("jdbc:mysql://" + Constants.SQLHostname + ":" + Constants.SQLPort + "/" + Constants.SQLDatabase + "?useSSL=" + Constants.SQLUseSSL);
       this.username = Constants.SQLUsername;
       this.password = Constants.SQLPassword;
     }

--- a/src/com/iConomy/util/Constants.java
+++ b/src/com/iConomy/util/Constants.java
@@ -49,6 +49,7 @@ public class Constants {
 	public static String SQLPort = "3306";
 	public static String SQLUsername = "root";
 	public static String SQLPassword = "";
+	public static boolean SQLUseSSL = false;
 
 	public static String SQLDatabase = "minecraft";
 	public static String SQLTable = "iConomy";
@@ -126,6 +127,8 @@ public class Constants {
 					"System.Database.Settings.MySQL.Username", SQLUsername);
 			SQLPassword = config.getString(
 					"System.Database.Settings.MySQL.Password", SQLPassword);
+			SQLUseSSL = config.getBoolean(
+					"System.Database.Settings.MySQL.UseSSL", false);
 
 		} catch (FileNotFoundException e) {
 			e.printStackTrace();

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,6 +1,6 @@
 name: iConomy
 main: com.iConomy.iConomy
-version: 5.05
+version: 5.06
 authors: [Nijikokun,ElgarL,LlmDl]
 softdepend: [Vault, Towny]
 load: startup


### PR DESCRIPTION
Resolves the following console output. This output is harmless, but extremely spamming making the logs hard to read.

I have tested it locally and on a server, works so far. Only thing I have not tested it on is older MySQL versions.

```
[18:09:04] [pool-11-thread-1/WARN]: Fri Mar 15 18:09:04 CDT 2019 WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.
```