### PR TITLE
Fix error on first startup.

### DIFF
--- a/src/main/java/com/iConomy/util/Downloader.java
+++ b/src/main/java/com/iConomy/util/Downloader.java
@@ -74,7 +74,7 @@ public class Downloader {
 
     //See: https://stackoverflow.com/a/1011126
     private void addURLToClassLoader(URL u) throws IOException {
-        URLClassLoader sysloader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+        URLClassLoader sysloader = (URLClassLoader) this.getClass().getClassLoader();
         Class<?> sysclass = URLClassLoader.class;
 
         try {


### PR DESCRIPTION
This will fix the class cast error and instead only result in a reflection warning. Ico5 will work without a reload.