### PR TITLE
Running the Holdings.add and Holdings.subtract method synchronously

### DIFF
--- a/src/main/java/com/iConomy/system/Holdings.java
+++ b/src/main/java/com/iConomy/system/Holdings.java
@@ -11,6 +11,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.DecimalFormat;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitRunnable;
 
 /**
  * Controls player Holdings, and Bank Account holdings.
@@ -116,17 +118,35 @@ public class Holdings {
     }
 
     public void add(double amount) {
-        double balance = get();
-        double ending = balance + amount;
-
-        math(amount, balance, ending);
+		if (Bukkit.isPrimaryThread()) {
+            double balance = get();
+            double ending = balance + amount;
+    
+            math(amount, balance, ending);
+        }else{
+            new BukkitRunnable(){
+                @Override
+                public void run(){
+                    add(amount);
+                }
+            }.runTask(iConomy.instance);
+        }
     }
 
     public void subtract(double amount) {
-        double balance = get();
-        double ending = balance - amount;
-
-        math(amount, balance, ending);
+		if (Bukkit.isPrimaryThread()) {
+            double balance = get();
+            double ending = balance - amount;
+    
+            math(amount, balance, ending);
+        }else{
+            new BukkitRunnable(){
+                @Override
+                public void run(){
+                    add(amount);
+                }
+            }.runTask(iConomy.instance);
+        }
     }
 
     public void divide(double amount) {

--- a/src/main/java/com/iConomy/system/Holdings.java
+++ b/src/main/java/com/iConomy/system/Holdings.java
@@ -143,7 +143,7 @@ public class Holdings {
             new BukkitRunnable(){
                 @Override
                 public void run(){
-                    add(amount);
+                    subtract(amount);
                 }
             }.runTask(iConomy.instance);
         }

--- a/src/main/java/com/iConomy/system/Holdings.java
+++ b/src/main/java/com/iConomy/system/Holdings.java
@@ -118,7 +118,7 @@ public class Holdings {
     }
 
     public void add(double amount) {
-		if (Bukkit.isPrimaryThread()) {
+        if (Bukkit.isPrimaryThread()) {
             double balance = get();
             double ending = balance + amount;
     
@@ -134,7 +134,7 @@ public class Holdings {
     }
 
     public void subtract(double amount) {
-		if (Bukkit.isPrimaryThread()) {
+        if (Bukkit.isPrimaryThread()) {
             double balance = get();
             double ending = balance - amount;
     


### PR DESCRIPTION
Running the add and subtract method synchronously to prevent the overriding of balances, for example:

balance = 100

add(10); => balance is 100, adding 10, new balance is 110, schedule BalanceUpdateEvent for next tick;
add(20); => balance is still 100 since its still the same tick, adding 20, new balance is 120, schedule BalanceUpdateEvent for next tick;

-- next tick --

setting balance to 110
setting balance to 120 => first add is ignored"