### PR TITLE
Making the Update and Set Events Asynchronous

### DIFF
--- a/src/main/java/com/iConomy/events/AccountSetEvent.java
+++ b/src/main/java/com/iConomy/events/AccountSetEvent.java
@@ -19,7 +19,7 @@ public class AccountSetEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
 	public AccountSetEvent(Holdings account, double balance) {
-		super();
+		super(!Bukkit.isPrimaryThread());
 		this.account = account;
 		this.balance = balance;
 	}
@@ -45,18 +45,8 @@ public class AccountSetEvent extends Event {
 	}
 
 	public void schedule(AccountSetEvent event) {
-
-		if (Bukkit.isPrimaryThread()) {
-			setBalance(event);
-
-		} else if (iConomy.instance.getServer().getScheduler().scheduleSyncDelayedTask(iConomy.instance, new Runnable() {
-
-			@Override
-			public void run() {
-				setBalance(event);
-			}
-		}, 1) == -1)
-			iConomy.instance.getServer().getLogger().warning("Could not schedule Account Set Event.");
+		
+		setBalance(event);
 	}
 
 	private void setBalance(AccountSetEvent event) {

--- a/src/main/java/com/iConomy/events/AccountUpdateEvent.java
+++ b/src/main/java/com/iConomy/events/AccountUpdateEvent.java
@@ -17,7 +17,7 @@ public class AccountUpdateEvent extends Event {
 	private static final HandlerList handlers = new HandlerList();
 
 	public AccountUpdateEvent(Holdings account, double previous, double balance, double amount) {
-		super();
+		super(!Bukkit.isPrimaryThread());
 		this.account = account;
 		this.previous = previous;
 		this.balance = balance;
@@ -66,18 +66,8 @@ public class AccountUpdateEvent extends Event {
 	}
 
 	public void schedule(AccountUpdateEvent event) {
-
-		if (Bukkit.isPrimaryThread()) {
-			update(event);
-
-		} else if (iConomy.instance.getServer().getScheduler().scheduleSyncDelayedTask(iConomy.instance, new Runnable() {
-
-			@Override
-			public void run() {
-				update(event);
-			}
-		}, 1) == -1)
-			System.out.println("[iConomy] Could not schedule Account Update Event.");
+		
+		update(event);
 	}
 
 	private void update(AccountUpdateEvent event) {


### PR DESCRIPTION
This is to stop the sync schedule to change the execution order. This can be a problem if many transactions are made in a short amount of time, for example when the towny new day task runs and collects the taxes.

I have not bothered to change anything in the naming scheme so I don't break any plugins that rely on those events, one should probably add a javadoc comment to the event class that it might be executed asynchronously